### PR TITLE
Update Dockerfile for Werkzeug version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,6 +46,7 @@ WORKDIR /srv/nostrtool/python-nostr
 RUN git checkout dev
 
 WORKDIR /srv/nostrtool
+RUN echo "Werkzeug==2.2.2" >> requirements.txt 
 RUN /srv/.env/bin/pip install -r requirements.txt --no-cache-dir
 
 WORKDIR /srv/nostrtool/src


### PR DESCRIPTION
Added line RUN echo "Werkzeug==2.2.2" >> requirements.txt  

Otherwise on 'docker compose up' you get error about 'cannot import name 'url_quote' from 'werkzeug.urls''